### PR TITLE
Reworked Load More logic to correct positioning of additional display rows

### DIFF
--- a/src/components/explore/ExploreItems.jsx
+++ b/src/components/explore/ExploreItems.jsx
@@ -5,6 +5,8 @@ import LoadItems from "../UI/loadItems";
 
 const ExploreItems = () => {
   const [isLoading, setIsLoading] = useState();
+  const [loadMore, setLoadMore] = useState(true);
+  const [loadMoreMore, setLoadMoreMore] = useState(true);
   const [exploreItems, setExploreItems] = useState([]);
   const [filter, setFilter] = useState("");
   const startItem = 0;
@@ -87,32 +89,37 @@ const ExploreItems = () => {
         </>
         :
         <>
-          <LoadItems start={ startItem } end={ endItem } exploreItems = { exploreItems } />
+        {loadMore
+          ?
+          <>
+          {loadMoreMore
+            ?
+            <>
+              <LoadItems start={ startItem } end={ endItem } exploreItems = { exploreItems } />
+              <div className="col-md-12 text-center">
+                <button className="btn-main lead" onClick={() => setLoadMoreMore(false)}>
+                  Load more
+                </button>
+              </div>
+            </>
+            :
+            <>
+              <LoadItems start={ startItem } end={ endItem + 4 } exploreItems = { exploreItems } />
+              <div className="col-md-12 text-center">
+                <button className="btn-main lead" onClick={() => setLoadMore(false)}>
+                  Load more
+                </button>
+              </div>
+            </>
+          }
+          </>
+          :
+          <>
+            <LoadItems start={ startItem } end={ endItem + 8 } exploreItems = { exploreItems } />
+          </>
+        }
         </>
       }
-      <div className="col-md-12 text-center">
-        <button id="loadmore" className="btn-main lead" onClick={() =>{
-          document.getElementById("loadmore").style.display = "none";
-          document.getElementById("section2").style.display = "flex";
-          document.getElementById("loadmore2").style.display = "block";
-          }}>
-          Load more
-        </button>
-      </div>
-      <div id="section2" style={{display: "none"}}>
-        <LoadItems start={ startItem + 8 } end={ endItem + 4 } exploreItems = { exploreItems } />
-      </div>
-      <div  id="loadmore2" style={{display: "none"}} className="col-md-12 text-center">
-        <button className="btn-main lead" onClick={() =>{
-          document.getElementById("loadmore2").style.display = "none";
-          document.getElementById("section3").style.display = "flex";
-        }}>
-          Load more
-        </button>
-      </div>
-      <div id="section3" style={{display: "none"}}>
-        <LoadItems start={ startItem + 12 } end={ endItem + 8 } exploreItems = { exploreItems } />
-      </div>
     </>
   );
 };


### PR DESCRIPTION
Task:
correct positioning of additional rows

How:
created LoadMore and LoadMoreMore boolean constants as a way to control how many items to display and whether or not the Load More button displays.
If both are true, only first 8 items display with Load More button
When clicking on Load More button, loadMoreMore is set to false, which shifts the executed code block to display first 12 items with load more button.
When clicking on Load More button again, loadMore is set to false, which shifts the executed code block to display all 16 items without Load More button.

By handling it this way, no additional rows are added (which created alignment issues with original vs new rows), so there is only a single block of code is executed with perfect alignment amongst all rows.

![Screenshot 2024-09-30 130200 Explore Items Load More corrected](https://github.com/user-attachments/assets/1e32ae2c-1e09-4871-9583-3eab6b79befc)
![Screenshot 2024-09-30 130328 Explore Items Load More 2 corrected](https://github.com/user-attachments/assets/aef5d6ad-c6b1-4314-9a44-571a03784fcd)
